### PR TITLE
Delete sgxpsw directory to allow reinstallation

### DIFF
--- a/uninstall-sgx-sdk-psw.sh
+++ b/uninstall-sgx-sdk-psw.sh
@@ -12,4 +12,8 @@ echo "- - - Removing linux-sgx repository - - -"
 rm -rf ../linux-sgx
 echo
 
+echo "- - - Removing SGX SDK Installation directory - - -"
+rm -fr /opt/intel/sgxpsw
+echo
+
 echo "Uninstall complete."


### PR DESCRIPTION
If trying to reinstall SGX, the binary installer silently stoppes the installation because the directory already exists. This is not catched by the installer.

Solution: In uninstall script, add a command to delete definitly the directory